### PR TITLE
Change metadata map value type from String to Object

### DIFF
--- a/android/src/main/java/com/mianjiajia/android_metadata/AndroidMetadataPlugin.java
+++ b/android/src/main/java/com/mianjiajia/android_metadata/AndroidMetadataPlugin.java
@@ -43,11 +43,11 @@ public class AndroidMetadataPlugin implements MethodCallHandler {
 
                 ApplicationInfo appInfo = pm.getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
 
-                Map<String, String> map = new HashMap<>();
+                Map<String, Object> map = new HashMap<>();
 
                 Set<String> ks = appInfo.metaData.keySet();
                 for (String key : ks) {
-                    map.put(key, String.valueOf(appInfo.metaData.getString(key)));
+                    map.put(key, String.valueOf(appInfo.metaData.get(key)));
                 }
 
                 result.success(map);


### PR DESCRIPTION
A very simple change... addresses request for type generalization in https://github.com/danieldai/android_metadata/issues/2 and https://github.com/danieldai/android_metadata/issues/3. 

For the Flutter dev side: When you are pulling these values, you should cast them to whatever type you need, since they are coming in as Objects. For example, I'm trying to get some Strings from Android metadata where Integers present in the metadata were throwing the error mentioned in https://github.com/danieldai/android_metadata/issues/3. 
```dart
AndroidMetadata.metaDataAsMap.then((map) {
      String exampleString = map['com.centerstack.KEY_OF_VALUE_NEEDED'].toString();
    });
```

If other users want to make use of these changes while the PR is under review, please update your pubspec.yaml as such:
```yaml
android_metadata:
    git:
      url: https://github.com/SamuelHaws/android_metadata
```

Don't forget to run `flutter pub upgrade` and  `flutter clean` before using my fork. Cheers! 🥂 

